### PR TITLE
Fix dttm for Django and add security session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.tox/
 coverage.xml
 junit-*.xml
+__pycache__

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -1,11 +1,19 @@
 # coding: utf-8
 import json
 import logging
-import requests
 import requests.adapters
 from collections import OrderedDict
 
 from . import conf, utils
+
+
+try:
+    from security.transport.security_requests import SecuritySession as Session
+    SECURITY_SESSION = True
+except ImportError:
+    from requests import Session
+    SECURITY_SESSION = False
+
 
 log = logging.getLogger('pycsob')
 
@@ -35,10 +43,13 @@ class CsobClient(object):
         self.key = self._get_key(private_key)
         self.pubkey = self._get_key(csob_pub_key)
 
-        session = requests.Session()
+        session = Session()
         session.headers = conf.HEADERS
         session.mount('https://', HTTPAdapter())
         session.mount('http://', HTTPAdapter())
+
+        if SECURITY_SESSION:
+            session.slug = 'pycsob'
 
         self._client = session
 

--- a/pycsob/utils.py
+++ b/pycsob/utils.py
@@ -1,5 +1,4 @@
 import sys
-import datetime
 import re
 from base64 import b64encode, b64decode
 from collections import OrderedDict
@@ -8,6 +7,13 @@ from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_v1_5
 
 from . import conf
+
+
+try:
+    from django.utils.timezone import localtime as now
+except ImportError:
+    from datetime import now
+
 
 if sys.version_info.major < 3:
     from urlparse import urljoin
@@ -70,7 +76,7 @@ def str_or_jsbool(v):
 
 
 def dttm(format_='%Y%m%d%H%M%S'):
-    return datetime.datetime.now().strftime(format_)
+    return now().strftime(format_)
 
 
 def validate_response(response, key):


### PR DESCRIPTION
This PR fixes this:
- use localized time when used together with Django
- use security session for requests, when `django-security-logger` is installed